### PR TITLE
cabal dep changes

### DIFF
--- a/testpack.cabal
+++ b/testpack.cabal
@@ -39,7 +39,7 @@ Library
 
  Build-Depends: base >= 3 && < 5,
                mtl, HUnit, 
-               QuickCheck >= 2.1.0.3
+               QuickCheck >= 2.1.0.3 && < 2.5
 
  If flag(splitBase)
    Build-Depends: base >= 3 && < 5, containers, random


### PR DESCRIPTION
Test.QuickCheck.Args has no field called "maxDiscard" in version 2.5 anymore. This patch simply disallows QuickCheck >= 2.5.

I saw some

```
#if MIN_VERSION_QuickCheck(2,3,0)
```

already in the code, but I was hesitant to do the same for QC-2.5 -- I really dislike conditional compilation.

Thanks for your time.
